### PR TITLE
Changed pip version in vagrant_cong/install.sh to 7.1.2  in order to keep compatibility with python 3.2

### DIFF
--- a/vagrant_conf/install.sh
+++ b/vagrant_conf/install.sh
@@ -3,7 +3,7 @@
 sudo apt-get update -y
 sudo apt-get install vim python-virtualenv python3-dev python3-setuptools -y
 
-sudo easy_install3 pip
+sudo easy_install3 "pip==7.1.2"
 
 cp /vagrant/example.db /vagrant/pythontutor.db
 


### PR DESCRIPTION
Starting from version 8.0.0 pip does not support python 3.2
[Source](https://pip.pypa.io/en/stable/news/)